### PR TITLE
Use ETag to determine if any S3 objects is changed or not

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "shell_script" "objects" {
         ${local.exclude_modified_files_option} >&2
     EOT
     read   = <<-EOT
-      aws s3api list-objects --bucket ${var.bucket} --query "{Keys:Contents[].Key}" --output json
+      aws s3api list-objects --bucket ${var.bucket} --query "{Contents: Contents[].{Key:Key, ETag:ETag}}" --output json
     EOT
     update = <<-EOT
       aws s3 sync --delete ${data.unarchive_file.main.output_dir} s3://${var.bucket} \
@@ -120,7 +120,7 @@ resource "shell_script" "objects_with_metadata" {
         --metadata-directive REPLACE >&2
     EOT
     read   = <<-EOT
-      aws s3api list-objects --bucket ${var.bucket} --query "{Keys:Contents[].Key}" --output json
+      aws s3api list-objects --bucket ${var.bucket} --query "{Contents: Contents[].{Key:Key, ETag:ETag}}" --output json
     EOT
     update = <<-EOT
       aws s3 sync --delete ${data.unarchive_file.main.output_dir} s3://${var.bucket} \

--- a/tests/advanced_test.go
+++ b/tests/advanced_test.go
@@ -14,35 +14,56 @@ func TestAdvanced(t *testing.T) {
 	// Arrange
 	bucket := "s3-deployment-561678142736"
 	region := "ap-northeast-1"
-	files := map[string]map[string]string{
+	files := map[string]S3Object{
 		"a.json": {
-			"Content-Type":     "application/json",
-			"Content-Language": "en-US",
+			Metadata: map[string]string{
+				"Content-Type":     "application/json",
+				"Content-Language": "en-US",
+			},
+			ETag: "\"d5524a5b020a0553b930cc3f2f8e4cce\"",
 		},
 		"b.json": {
-			"Content-Type":        "binary/octet-stream",
-			"Cache-Control":       "public, max-age=31536000, immutable",
-			"Content-Disposition": "inline",
-			"Content-Encoding":    "compress",
-			"Content-Language":    "ja-JP",
+			Metadata: map[string]string{
+				"Content-Type":        "binary/octet-stream",
+				"Cache-Control":       "public, max-age=31536000, immutable",
+				"Content-Disposition": "inline",
+				"Content-Encoding":    "compress",
+				"Content-Language":    "ja-JP",
+			},
+			ETag: "\"64cd52391a8a2843d7cb347e872720b0\"",
 		},
 		"config-09e8d29e.js": {
-			"Content-Type":  "text/javascript",
-			"Cache-Control": "public, max-age=0, must-revalidate",
+			Metadata: map[string]string{
+				"Content-Type":  "text/javascript",
+				"Cache-Control": "public, max-age=0, must-revalidate",
+			},
+			ETag: "\"5f56ab0a8e07afb6ef5885a8486927ab\"",
 		},
 		"index.html": {
-			"Content-Type":  "text/html",
-			"Cache-Control": "public, max-age=0, must-revalidate",
+			Metadata: map[string]string{
+				"Content-Type":  "text/html",
+				"Cache-Control": "public, max-age=0, must-revalidate",
+			},
+			ETag: "\"faeee5e2efb928e33b0eb232a1ce1f85\"",
 		},
 		"octocat.png": {
-			"Content-Type": "image/png",
+			Metadata: map[string]string{
+				"Content-Type": "image/png",
+			},
+			ETag: "\"f1d23c21191e970573e34ceb555c332b\"",
 		},
 		"script.js": {
-			"Content-Type":  "text/javascript",
-			"Cache-Control": "public, max-age=0, must-revalidate",
+			Metadata: map[string]string{
+				"Content-Type":  "text/javascript",
+				"Cache-Control": "public, max-age=0, must-revalidate",
+			},
+			ETag: "\"847706ee8f66d4a9b30302446279ea5e\"",
 		},
 		"style.css": {
-			"Content-Type": "text/css",
+			Metadata: map[string]string{
+				"Content-Type": "text/css",
+			},
+			ETag: "\"ed143c36d3a6cb0fec57de6d828bb52a\"",
 		},
 	}
 

--- a/tests/simple_test.go
+++ b/tests/simple_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"log"
+	"strings"
 	"testing"
 )
 
@@ -14,27 +15,48 @@ func TestSimple(t *testing.T) {
 	// Arrange
 	bucket := "s3-deployment-simple-561678142736"
 	region := "ap-northeast-1"
-	files := map[string]map[string]string{
+	files := map[string]S3Object{
 		"a.json": {
-			"Content-Type": "application/json",
+			Metadata: map[string]string{
+				"Content-Type": "application/json",
+			},
+			ETag: "\"d5524a5b020a0553b930cc3f2f8e4cce\"",
 		},
 		"b.json": {
-			"Content-Type": "application/json",
+			Metadata: map[string]string{
+				"Content-Type": "application/json",
+			},
+			ETag: "\"8f9c289b2cb8faa7199cde10bd185b99\"",
 		},
 		"config-09e8d29e.js": {
-			"Content-Type": "application/javascript",
+			Metadata: map[string]string{
+				"Content-Type": "application/javascript",
+			},
+			ETag: "\"96d43a1e51087a6a225bb56885a63553\"",
 		},
 		"index.html": {
-			"Content-Type": "text/html",
+			Metadata: map[string]string{
+				"Content-Type": "text/html",
+			},
+			ETag: "\"faeee5e2efb928e33b0eb232a1ce1f85\"",
 		},
 		"octocat.png": {
-			"Content-Type": "image/png",
+			Metadata: map[string]string{
+				"Content-Type": "image/png",
+			},
+			ETag: "\"f1d23c21191e970573e34ceb555c332b\"",
 		},
 		"script.js": {
-			"Content-Type": "application/javascript",
+			Metadata: map[string]string{
+				"Content-Type": "application/javascript",
+			},
+			ETag: "\"847706ee8f66d4a9b30302446279ea5e\"",
 		},
 		"style.css": {
-			"Content-Type": "text/css",
+			Metadata: map[string]string{
+				"Content-Type": "text/css",
+			},
+			ETag: "\"ed143c36d3a6cb0fec57de6d828bb52a\"",
 		},
 	}
 
@@ -69,6 +91,23 @@ func TestSimple(t *testing.T) {
 	})
 	if err != nil {
 		log.Fatalf("cannot add an object, %v", err)
+	}
+
+	// Act
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Assert
+	assertOutputs(t, terraformOptions, map[string]interface{}{})
+	assertObjects(t, svc, bucket, files)
+
+	// Update an object
+	_, err = svc.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("b.json"),
+		Body:   strings.NewReader("{\n  \"a\": \"9\"\n}\n"),
+	})
+	if err != nil {
+		log.Fatalf("cannot update an object, %v", err)
 	}
 
 	// Act


### PR DESCRIPTION
## 背景
- 現在、 shell_script リソースでは read スクリプトでS3バケットのオブジェクトのキーのリストを取得し、その状態を保持している
- そのためオブジェクトが追加されたり、削除されたりした後に terraform plan を実行すると変更が検出される
  - その後、 terraform apply により shell_script リソースの update スクリプトが実行されて正しい状態に戻る
- ただしオブジェクトをが更新された場合はオブジェクトのキーのリストに変化は無いため、変更を検出できない

## 概要
- よって shell_script リソースの read スクリプト でETagを取得し、状態を保持するようにする
- これによりオブジェクトが更新された場合、ETagの値が変化しているので変更を検出することができる