### PR TITLE
Add variable to receive dependencies

### DIFF
--- a/examples/advanced/dependencies.tf
+++ b/examples/advanced/dependencies.tf
@@ -61,3 +61,15 @@ data "aws_iam_policy_document" "oai" {
     }
   }
 }
+
+resource "terraform_data" "dummy_resource_1" {
+  provisioner "local-exec" {
+    command = "echo 'Dummy resource 1'"
+  }
+}
+
+resource "terraform_data" "dummy_resource_2" {
+  provisioner "local-exec" {
+    command = "echo 'Dummy resource 2'"
+  }
+}

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -53,4 +53,6 @@ module "s3_deployment" {
     }
   ]
   cloudfront_distribution_id = aws_cloudfront_distribution.main.id
+
+  resources_depends_on = [terraform_data.dummy_resource_1, terraform_data.dummy_resource_2]
 }

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,10 @@ locals {
   exclude_modified_files_option = join(" ", distinct([for k, v in local.modified_files : "--exclude '${k}'"]))
 }
 
+resource "terraform_data" "dummy_resource_deps" {
+  depends_on = var.resources_depends_on
+}
+
 // As the number of files increases, the output of the `terraform plan` becomes very long and difficult to read.
 // So we utilize `aws s3 cp` and `aws s3 sync` to copy almost all objects.
 resource "shell_script" "objects" {
@@ -86,13 +90,8 @@ resource "shell_script" "objects" {
   }
   interpreter = ["bash", "-c"]
 
-  depends_on = [var.resources_depends_on]
+  depends_on = [terraform_data.dummy_resource_deps]
 }
-
-resource "terraform_data" "dummy_resource_deps" {
-  depends_on = var.resources_depends_on
-}
-
 
 // Files with metadata are copied separately
 resource "shell_script" "objects_with_metadata" {

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ locals {
 }
 
 resource "terraform_data" "dummy_resource_deps" {
-  depends_on = var.resources_depends_on
+  depends_on = [var.resources_depends_on]
 }
 
 // As the number of files increases, the output of the `terraform plan` becomes very long and difficult to read.

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ EOT
 }
 
 variable "resources_depends_on" {
-  description = "Values added to the depends_on meta-argument for the resources only"
-  type        = any
-  default     = list(any)
+  description = "Additional value to be added to the depends_on meta-argument for resources only"
+  type        = list(any)
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ EOT
 }
 
 variable "resources_depends_on" {
-  description = "Additional value to be added to the depends_on meta-argument for resources only"
+  description = "Values added to the depends_on meta-argument for the resources only"
   type        = any
-  default     = null
+  default     = list(any)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ EOT
 }
 
 variable "resources_depends_on" {
-  description = "Additional value to be added to the depends_on meta-argument for resources only"
+  description = "Optional 'depends_on' values for resources only to control the deployment order"
   type        = list(any)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,9 @@ EOT
   }))
   default = []
 }
+
+variable "resources_depends_on" {
+  description = "Additional value to be added to the depends_on meta-argument for resources only"
+  type        = any
+  default     = null
+}


### PR DESCRIPTION
## 背景

- デプロイの順序を制御するためには、本moduleに対して先にデプロイを実行するリソースを depends_on 設定することが考えられる
- その際、以下のようなエラーメッセージがPlan実行時に表示されることがある

```
╷
│ Error: Invalid for_each argument
│ 
│   on .terraform/modules/sample-basic-front-01.s3_deployment/main.tf line 154, in resource "aws_s3_object" "modified":
│  154:   for_each = local.modified_files
│     ├────────────────
│     │ local.modified_files will be known only after apply
│ 
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
│ 
│ When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.
│ 
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
```

- 現状、 Plan時に unarchive データソースでフロントのバンドルのZipファイルを展開し、 for_each で aws_s3_object リソースの個数を確定させている
- ところが、本module に任意のリソースを depends_on として指定すると unarchive データソースにも依存がかかり、Apply後でないとリソースの個数が確定できないとTerraformに判断されてしまうのが原因

## 概要

- リソースのみに対して depends_on を設定できる入力変数を用意する
- データソースには depends_on がかからないので、これで上記の問題を解消できる

## 動作確認

- `examples/advanced` において `terraform graph` を実行し、 dependency が意図通りに設定されていることを確認
- サンプルにて core, front のバージョンを同時に更新した際に、coreのデプロイ完了後にfrontのデプロイが実行されることを確認
