### PR TITLE
Do not delete objects when the resource is destroyed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,11 +79,10 @@ resource "shell_script" "objects" {
         ${local.exclude_files_with_metadata_option} \
         ${local.exclude_modified_files_option} >&2
     EOT
-    delete = <<-EOT
-      aws s3 rm --recursive s3://${var.bucket} \
-        ${local.exclude_files_with_metadata_option} \
-        ${local.exclude_modified_files_option} >&2
-    EOT
+    // If we delete objects when this resource is replaced by changing triggers, there will be a moment when both
+    // new and old objects are not present.
+    // So we do not perform deletion when the resource is destroyed.
+    delete = ""
   }
   interpreter = ["bash", "-c"]
 }
@@ -142,12 +141,10 @@ resource "shell_script" "objects_with_metadata" {
         %{~endif~}
         --metadata-directive REPLACE >&2
     EOT
-    delete = <<-EOT
-      aws s3 rm --recursive s3://${var.bucket} \
-        --exclude "*" \
-        ${local.include_files_with_metadata_options[count.index]} \
-        ${local.exclude_modified_files_option} >&2
-    EOT
+    // If we delete objects when this resource is replaced by changing triggers, there will be a moment when both
+    // new and old objects are not present.
+    // So we do not perform deletion when the resource is destroyed.
+    delete = ""
   }
   interpreter = ["bash", "-c"]
   depends_on  = [shell_script.objects]


### PR DESCRIPTION
- shell_script リソースが triggers 変数の更新により再作成（Destroy→Create）された場合、削除と作成の間に新旧のオブジェクトが存在しないタイミングが発生する
- そのためDestroy時にオブジェクトを削除するのをやめる