### PR TITLE
Use shell_script resource to copy modified files

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -39,7 +39,7 @@ module "s3_deployment" {
       content_language    = "ja-JP"
     },
     {
-      glob             = "*.json"
+      glob             = "a.json"
       content_language = "en-US"
     },
     {

--- a/examples/advanced/outputs.tf
+++ b/examples/advanced/outputs.tf
@@ -1,3 +1,0 @@
-output "s3_objects" {
-  value = { for o in module.s3_deployment.s3_objects_modified : o.key => o.content }
-}

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -1,3 +1,0 @@
-output "s3_objects" {
-  value = { for o in module.s3_deployment.s3_objects_modified : o.key => o.content }
-}

--- a/main.tf
+++ b/main.tf
@@ -9,24 +9,8 @@ locals {
       content_language    = e.content_language
     }
   ]
-  include_files_with_metadata_options = [for e in local.object_metadata : join(" ", [for f in setsubtract(e.filenames, keys(local.modified_files)) : "--include '${f}'"])]
+  include_files_with_metadata_options = [for e in local.object_metadata : join(" ", [for f in e.filenames : "--include '${f}'"])]
   exclude_files_with_metadata_option  = join(" ", distinct(flatten([for e in local.object_metadata : [for f in e.filenames : "--exclude '${f}'"]])))
-
-  // Mapping of filename to metadata.
-  // If a file matches with glob patterns of the multiple settings entries, only the first matched one is used
-  object_metadata_map = {
-    for d in flatten([
-      for e in local.object_metadata : [
-        for f in e.filenames : {
-          filename            = f
-          content_type        = e.content_type
-          cache_control       = e.cache_control
-          content_disposition = e.content_disposition
-          content_encoding    = e.content_encoding
-          content_language    = e.content_language
-      }]
-    ]) : d.filename => d...
-  }
 
   // Mapping of filename to the replaced content.
   // If a file matches with glob patterns of the multiple settings entries, only the first matched one is used
@@ -53,8 +37,32 @@ locals {
     ]) : d.filename => d.content...
   }
 
-  modified_files                = merge(local.file_replacements, local.json_overrides)
-  exclude_modified_files_option = join(" ", distinct([for k, v in local.modified_files : "--exclude '${k}'"]))
+  modified_files = merge(local.file_replacements, local.json_overrides)
+}
+
+data "temporary_directory" "archive" {
+  name = "s3-deployment/${md5(var.archive_path)}"
+}
+
+data "unarchive_file" "main" {
+  type        = "zip"
+  source_file = var.archive_path
+  patterns    = var.file_patterns
+  excludes    = var.file_exclusions
+  output_dir  = data.temporary_directory.archive.id
+}
+
+// Modify files
+data "shell_script" "modifications" {
+  for_each = local.modified_files
+  lifecycle_commands {
+    read = <<-EOT
+      cat <<-EOF > '${data.temporary_directory.archive.id}/${each.key}'
+      ${each.value[0]}
+      EOF
+    EOT
+  }
+  depends_on = [data.unarchive_file.main]
 }
 
 // As the number of files increases, the output of the `terraform plan` becomes very long and difficult to read.
@@ -64,20 +72,14 @@ resource "shell_script" "objects" {
     objects               = filemd5(var.archive_path),
     objects_with_metadata = md5(jsonencode(var.object_metadata))
   }
-  // Copy all files except those to be modified or those with metadata 
+  // Copy all files without metadata
   lifecycle_commands {
     create = <<-EOT
       aws s3 sync --delete ${data.unarchive_file.main.output_dir} s3://${var.bucket} \
-        ${local.exclude_files_with_metadata_option} \
-        ${local.exclude_modified_files_option} >&2
+        ${local.exclude_files_with_metadata_option} >&2
     EOT
     read   = <<-EOT
       aws s3api list-objects --bucket ${var.bucket} --query "{Keys:Contents[].Key}" --output json
-    EOT
-    update = <<-EOT
-      aws s3 sync --delete ${data.unarchive_file.main.output_dir} s3://${var.bucket} \
-        ${local.exclude_files_with_metadata_option} \
-        ${local.exclude_modified_files_option} >&2
     EOT
     // If we delete objects when this resource is replaced by changing triggers, there will be a moment when both
     // new and old objects are not present.
@@ -96,11 +98,11 @@ resource "shell_script" "objects_with_metadata" {
     objects               = filemd5(var.archive_path),
     objects_with_metadata = md5(jsonencode(var.object_metadata))
   }
-  // Copy files with metadata, excluding those to be modified
+  // Copy files with metadata
   lifecycle_commands {
     create = <<-EOT
       aws s3 sync --delete ${data.unarchive_file.main.output_dir} s3://${var.bucket} \
-        --exclude "*" \
+        --exclude '*' \
         ${local.include_files_with_metadata_options[count.index]} \
         %{~if local.object_metadata[count.index].content_type != null~}
         --content-type '${local.object_metadata[count.index].content_type}' \
@@ -122,27 +124,6 @@ resource "shell_script" "objects_with_metadata" {
     read   = <<-EOT
       aws s3api list-objects --bucket ${var.bucket} --query "{Keys:Contents[].Key}" --output json
     EOT
-    update = <<-EOT
-      aws s3 sync --delete ${data.unarchive_file.main.output_dir} s3://${var.bucket} \
-        --exclude "*" \
-        ${local.include_files_with_metadata_options[count.index]} \
-        %{~if local.object_metadata[count.index].content_type != null~}
-        --content-type '${local.object_metadata[count.index].content_type}' \
-        %{~endif~}
-        %{~if local.object_metadata[count.index].cache_control != null~}
-        --cache-control '${local.object_metadata[count.index].cache_control}' \
-        %{~endif~}
-        %{~if local.object_metadata[count.index].content_disposition != null~}
-        --content-disposition '${local.object_metadata[count.index].content_disposition}' \
-        %{~endif~}
-        %{~if local.object_metadata[count.index].content_encoding != null~}
-        --content-encoding '${local.object_metadata[count.index].content_encoding}' \
-        %{~endif~}
-        %{~if local.object_metadata[count.index].content_language != null~}
-        --content-language '${local.object_metadata[count.index].content_language}' \
-        %{~endif~}
-        --metadata-directive REPLACE >&2
-    EOT
     // If we delete objects when this resource is replaced by changing triggers, there will be a moment when both
     // new and old objects are not present.
     // So we do not perform deletion when the resource is destroyed.
@@ -151,22 +132,6 @@ resource "shell_script" "objects_with_metadata" {
   interpreter = ["bash", "-c"]
 
   depends_on = [shell_script.objects, var.resources_depends_on]
-}
-
-// Use `aws_s3_object` resource for modified files
-resource "aws_s3_object" "modified" {
-  for_each = local.modified_files
-
-  bucket              = var.bucket
-  key                 = each.key
-  content             = each.value[0]
-  content_type        = try(local.object_metadata_map[each.key][0].content_type, try(local.file_types[regex("\\.[^.]+$", each.key)], null))
-  cache_control       = try(local.object_metadata_map[each.key][0].cache_control, null)
-  content_disposition = try(local.object_metadata_map[each.key][0].content_disposition, null)
-  content_encoding    = try(local.object_metadata_map[each.key][0].content_encoding, null)
-  content_language    = try(local.object_metadata_map[each.key][0].content_language, null)
-
-  depends_on = [shell_script.objects, shell_script.objects_with_metadata, var.resources_depends_on]
 }
 
 resource "terraform_data" "invalidation" {
@@ -180,17 +145,5 @@ resource "terraform_data" "invalidation" {
     command     = "./${path.module}/scripts/invalidate.sh '${var.cloudfront_distribution_id}'"
     interpreter = ["bash", "-c"]
   }
-  depends_on = [shell_script.objects, shell_script.objects_with_metadata, aws_s3_object.modified, var.resources_depends_on]
-}
-
-data "temporary_directory" "archive" {
-  name = "s3-deployment/${md5(var.archive_path)}"
-}
-
-data "unarchive_file" "main" {
-  type        = "zip"
-  source_file = var.archive_path
-  patterns    = var.file_patterns
-  excludes    = var.file_exclusions
-  output_dir  = data.temporary_directory.archive.id
+  depends_on = [shell_script.objects, shell_script.objects_with_metadata, var.resources_depends_on]
 }

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,8 @@ data "shell_script" "modifications" {
       EOF
     EOT
   }
+  interpreter = ["bash", "-c"]
+
   depends_on = [data.unarchive_file.main]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,0 @@
-output "s3_objects_modified" {
-  value       = aws_s3_object.modified
-  description = "S3 objects replaced or overridden"
-}

--- a/tests/advanced_expected.json
+++ b/tests/advanced_expected.json
@@ -1,4 +1,0 @@
-{
-  "b.json": "{\"a\":\"1\",\"h\":\"2\",\"i\":{\"j\":3,\"k\":\"4\"}}",
-  "config-09e8d29e.js": "const c = JSON.parse('{\"abc\":[1,2,3],\"unicorns\":\"awesome\"}'); export default c;"
-}

--- a/tests/advanced_test.go
+++ b/tests/advanced_test.go
@@ -14,35 +14,51 @@ func TestAdvanced(t *testing.T) {
 	// Arrange
 	bucket := "s3-deployment-561678142736"
 	region := "ap-northeast-1"
-	files := map[string]map[string]string{
+	files := map[string]S3Object{
 		"a.json": {
-			"Content-Type":     "application/json",
-			"Content-Language": "en-US",
+			Metadata: map[string]string{
+				"Content-Type":     "application/json",
+				"Content-Language": "en-US",
+			},
 		},
 		"b.json": {
-			"Content-Type":        "binary/octet-stream",
-			"Cache-Control":       "public, max-age=31536000, immutable",
-			"Content-Disposition": "inline",
-			"Content-Encoding":    "compress",
-			"Content-Language":    "ja-JP",
+			Metadata: map[string]string{
+				"Content-Type":        "binary/octet-stream",
+				"Cache-Control":       "public, max-age=31536000, immutable",
+				"Content-Disposition": "inline",
+				"Content-Encoding":    "compress",
+				"Content-Language":    "ja-JP",
+			},
+			Content: "{\"a\":\"1\",\"h\":\"2\",\"i\":{\"j\":3,\"k\":\"4\"}}\n",
 		},
 		"config-09e8d29e.js": {
-			"Content-Type":  "text/javascript",
-			"Cache-Control": "public, max-age=0, must-revalidate",
+			Metadata: map[string]string{
+				"Content-Type":  "text/javascript",
+				"Cache-Control": "public, max-age=0, must-revalidate",
+			},
+			Content: "const c = JSON.parse('{\"abc\":[1,2,3],\"unicorns\":\"awesome\"}'); export default c;\n",
 		},
 		"index.html": {
-			"Content-Type":  "text/html",
-			"Cache-Control": "public, max-age=0, must-revalidate",
+			Metadata: map[string]string{
+				"Content-Type":  "text/html",
+				"Cache-Control": "public, max-age=0, must-revalidate",
+			},
 		},
 		"octocat.png": {
-			"Content-Type": "image/png",
+			Metadata: map[string]string{
+				"Content-Type": "image/png",
+			},
 		},
 		"script.js": {
-			"Content-Type":  "text/javascript",
-			"Cache-Control": "public, max-age=0, must-revalidate",
+			Metadata: map[string]string{
+				"Content-Type":  "text/javascript",
+				"Cache-Control": "public, max-age=0, must-revalidate",
+			},
 		},
 		"style.css": {
-			"Content-Type": "text/css",
+			Metadata: map[string]string{
+				"Content-Type": "text/css",
+			},
 		},
 	}
 
@@ -63,11 +79,10 @@ func TestAdvanced(t *testing.T) {
 	}
 
 	// Act
-	terraform.InitAndApply(t, terraformOptions)
+	out := terraform.InitAndApply(t, terraformOptions)
 
 	// Assert
-	expected := readJson(t, "../tests/advanced_expected.json")
-	assertOutputs(t, terraformOptions, expected)
+	assertResult(t, out, 5, 0, 5)
 	assertObjects(t, svc, bucket, files)
 
 	// Add an object
@@ -81,10 +96,10 @@ func TestAdvanced(t *testing.T) {
 	}
 
 	// Act
-	terraform.InitAndApply(t, terraformOptions)
+	out = terraform.InitAndApply(t, terraformOptions)
 
 	// Assert
-	assertOutputs(t, terraformOptions, expected)
+	assertResult(t, out, 5, 0, 5)
 	assertObjects(t, svc, bucket, files)
 
 	// Delete an object
@@ -97,9 +112,9 @@ func TestAdvanced(t *testing.T) {
 	}
 
 	// Act
-	terraform.InitAndApply(t, terraformOptions)
+	out = terraform.InitAndApply(t, terraformOptions)
 
 	// Assert
-	assertOutputs(t, terraformOptions, expected)
+	assertResult(t, out, 5, 0, 5)
 	assertObjects(t, svc, bucket, files)
 }

--- a/tests/simple_test.go
+++ b/tests/simple_test.go
@@ -14,27 +14,41 @@ func TestSimple(t *testing.T) {
 	// Arrange
 	bucket := "s3-deployment-simple-561678142736"
 	region := "ap-northeast-1"
-	files := map[string]map[string]string{
+	files := map[string]S3Object{
 		"a.json": {
-			"Content-Type": "application/json",
+			Metadata: map[string]string{
+				"Content-Type": "application/json",
+			},
 		},
 		"b.json": {
-			"Content-Type": "application/json",
+			Metadata: map[string]string{
+				"Content-Type": "application/json",
+			},
 		},
 		"config-09e8d29e.js": {
-			"Content-Type": "application/javascript",
+			Metadata: map[string]string{
+				"Content-Type": "application/javascript",
+			},
 		},
 		"index.html": {
-			"Content-Type": "text/html",
+			Metadata: map[string]string{
+				"Content-Type": "text/html",
+			},
 		},
 		"octocat.png": {
-			"Content-Type": "image/png",
+			Metadata: map[string]string{
+				"Content-Type": "image/png",
+			},
 		},
 		"script.js": {
-			"Content-Type": "application/javascript",
+			Metadata: map[string]string{
+				"Content-Type": "application/javascript",
+			},
 		},
 		"style.css": {
-			"Content-Type": "text/css",
+			Metadata: map[string]string{
+				"Content-Type": "text/css",
+			},
 		},
 	}
 
@@ -55,10 +69,10 @@ func TestSimple(t *testing.T) {
 	}
 
 	// Act
-	terraform.InitAndApply(t, terraformOptions)
+	out := terraform.InitAndApply(t, terraformOptions)
 
 	// Assert
-	assertOutputs(t, terraformOptions, map[string]interface{}{})
+	assertResult(t, out, 1, 0, 1)
 	assertObjects(t, svc, bucket, files)
 
 	// Add an object
@@ -72,10 +86,10 @@ func TestSimple(t *testing.T) {
 	}
 
 	// Act
-	terraform.InitAndApply(t, terraformOptions)
+	out = terraform.InitAndApply(t, terraformOptions)
 
 	// Assert
-	assertOutputs(t, terraformOptions, map[string]interface{}{})
+	assertResult(t, out, 1, 0, 1)
 	assertObjects(t, svc, bucket, files)
 
 	// Delete an object
@@ -88,9 +102,9 @@ func TestSimple(t *testing.T) {
 	}
 
 	// Act
-	terraform.InitAndApply(t, terraformOptions)
+	out = terraform.InitAndApply(t, terraformOptions)
 
 	// Assert
-	assertOutputs(t, terraformOptions, map[string]interface{}{})
+	assertResult(t, out, 1, 0, 1)
 	assertObjects(t, svc, bucket, files)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ EOT
 variable "object_metadata" {
   description = <<-EOT
   Object metadata settings.
-  * glob                : Glob pattern to match files to set metadata values
+  * glob                : Glob pattern to match files to set metadata values. The patterns must not be overlapped.
   * cache_control       : Cache-Control metadata value
   * content_disposition : Content-Disposition metadata value
   * content_encoding    : Content-Encoding metadata value


### PR DESCRIPTION
- file_replacements と json_overrides で修正したファイルについて、 aws_s3_object を使うのをやめて shell_script resource と datasource のあわせ技でアップロードするようにする
- shell_script の update lifecycle を削除
  - どうせ再作成すれば良いので
- object_metadata 変数へのドキュメントを追加
  - globパターンが重複した場合、並列に処理される都合上どれか1つの設定のみが適用される