### PR TITLE
Fix for terraform 1.13.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,8 +116,8 @@ resource "shell_script" "objects" {
       ${local.aws_config_environments}
 
       TEMP_DIR=$(mktemp -d)
-      cp -R ${data.temporary_directory.archive.id}/ "$${TEMP_DIR}"
-      cp -R ${data.temporary_directory.modified.id}/ "$${TEMP_DIR}"
+      rsync -a ${data.temporary_directory.archive.id}/ "$${TEMP_DIR}"
+      rsync -a ${data.temporary_directory.modified.id}/ "$${TEMP_DIR}"
       cd "$${TEMP_DIR}"
 
       aws s3 cp --recursive . s3://${var.bucket} ${join(" ", [for f in local.files_with_metadata : "--exclude '${f}'"])} >&2

--- a/main.tf
+++ b/main.tf
@@ -117,8 +117,8 @@ resource "shell_script" "objects" {
       ${local.aws_config_environments}
 
       TEMP_DIR=$(mktemp -d)
-      cp -r ${data.temporary_directory.archive.id}/ "$${TEMP_DIR}"
-      cp -r ${data.temporary_directory.modified.id}/ "$${TEMP_DIR}"
+      cp -R ${data.temporary_directory.archive.id}/. "$${TEMP_DIR}"
+      cp -R ${data.temporary_directory.modified.id}/. "$${TEMP_DIR}"
       cd "$${TEMP_DIR}"
 
       aws s3 cp --recursive . s3://${var.bucket} ${join(" ", [for f in local.files_with_metadata : "--exclude '${f}'"])} >&2

--- a/tests/advanced_test.go
+++ b/tests/advanced_test.go
@@ -79,6 +79,7 @@ func TestAdvanced(t *testing.T) {
 		Vars: map[string]interface{}{
 			"archive_path": "test.zip",
 		},
+		Reconfigure: true,
 	}
 
 	// Act

--- a/tests/simple_test.go
+++ b/tests/simple_test.go
@@ -62,6 +62,7 @@ func TestSimple(t *testing.T) {
 		TerraformDir: "../examples/simple",
 		Upgrade:      true,
 		LockTimeout:  "5m",
+		Reconfigure:  true,
 	}
 
 	// Act


### PR DESCRIPTION
Due to [the change](https://github.com/hashicorp/terraform/pull/37001) in Terraform 1.13.0, this module now started throwing the following error

```
│ Error: Error in function call
│
│   on ../../main.tf line 33, in locals:
│   33:           content : jsonencode(merge(jsondecode(file("${data.unarchive_file.main.output_dir}/${f}")), jsondecode(e.content)))
│     ├────────────────
│     │ data.unarchive_file.main.output_dir is ".terraform/tmp/s3-deployment/8713a1c910678e159a5e915bf4779939"
│
│ Call to function "file" failed: function returned an inconsistent result.
```

From 1.13.x Terraform does not allow change the file content during the plan and apply. So we must copy the whole content to the temporary directory before sync